### PR TITLE
Улучшение кодогенерации для Python и исправление скролла колёсиком мышки

### DIFF
--- a/generators/py.json
+++ b/generators/py.json
@@ -9,7 +9,7 @@
 		"template":"if %cond%:%branch1%\nelse: %branch2%\n"
 	},
 	"for": {
-		"template":"for %var% in xrange(%from%, %to%):%branch1%\n"
+		"template":"for %var% in range(%from%, %to%):%branch1%\n"
 	},
 	"pre": {
 		"template":"while %cond%:%branch1%\n"
@@ -18,10 +18,10 @@
 		"template":"while True:%branch1%\n\tif %cond%:\n\t\tbreak"
 	},
 	"assign": {
-		"template":"%dest% = %src%;"
+		"template":"%dest% = %src%"
 	},
 	"process": {
-		"template": "%text%;"
+		"template": "%text%"
 	},
 	"io": {
 		"template": "%vars%",
@@ -36,6 +36,9 @@
 		"list": ["vars"],
 		"separator": ",",
 		"glue": ", "
-
-	}
+	},
+    
+    "additional_settings": {
+    	"indentation_preference": "    "
+    }
 }

--- a/generators/py.json
+++ b/generators/py.json
@@ -3,10 +3,11 @@
         "en_US":"Python"
     },
 	"algorithm" : {
-		"template" : "def main():%branch1%\n"
+		"template" : "def main():%branch1%\nmain()"
 	},
 	"if": {
-		"template":"if %cond%:%branch1%\nelse: %branch2%\n"
+		"template":"if %cond%:%branch1%\nelse: %branch2%",
+        "template_shortened":"if %cond%:%branch1%"
 	},
 	"for": {
 		"template":"for %var% in range(%from%, %to%):%branch1%\n"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -43,7 +43,7 @@ void AfcScrollArea::wheelEvent(QWheelEvent *event)
         event->ignore();
         emit zoomStepped(event->delta() / 120);
     }
-    else{
+    else {
         if((event->modifiers() & Qt::ShiftModifier) == 0) {
             QScrollBar * vsb = verticalScrollBar();
             if (vsb != NULL) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -43,7 +43,23 @@ void AfcScrollArea::wheelEvent(QWheelEvent *event)
         event->ignore();
         emit zoomStepped(event->delta() / 120);
     }
-    else event->accept();
+    else{
+        if((event->modifiers() & Qt::ShiftModifier) == 0) {
+            QScrollBar * vsb = verticalScrollBar();
+            if (vsb != NULL) {
+                /* scroll vertically */
+                vsb->setValue(vsb->value() - event->delta());
+            }
+        }
+        else {
+            QScrollBar * gsb = horizontalScrollBar();
+            if (gsb != NULL) {
+                /* scroll horizontally */
+                gsb->setValue(gsb->value() - event->delta());
+            }
+        }
+        event->accept();
+    }
 }
 
 

--- a/sourcecodegenerator.cpp
+++ b/sourcecodegenerator.cpp
@@ -36,8 +36,19 @@ QString SourceCodeGenerator::applyRule(const QDomDocument &xml) {
 }
 
 QString SourceCodeGenerator::processElement(const QDomNode &element, int level) {
-    QString sp = QString("  ").repeated(level);
     QJsonObject obj = rule.object().value(element.nodeName()).toObject();
+    QString sp;
+    if (rule.object().contains("additional_settings")) {
+        /* if json specified indentation string it will use */
+        sp = rule.object().value("additional_settings").toObject()["indentation_preference"].toString();
+    }
+    else {
+        /* otherwise use default */
+        sp = QString("  ");
+    }
+    sp = sp.repeated(level);
+
+
     QString tpl = sp+obj.value("template").toString();
     for(int i = 0; i < element.attributes().size(); ++i) {
        if(obj.contains("list")) {

--- a/sourcecodegenerator.cpp
+++ b/sourcecodegenerator.cpp
@@ -48,8 +48,22 @@ QString SourceCodeGenerator::processElement(const QDomNode &element, int level) 
     }
     sp = sp.repeated(level);
 
+    bool else_present = false;
+    /* if element is "if" AND second item (number 1) is branch AND it is NOT empty mean "else" is present */
+    if (element.nodeName() == "if" && element.childNodes().item(1).nodeName() == "branch") {
+        if (element.childNodes().item(1).childNodes().size() > 0) {
+            else_present = true;
+        }
+    }
 
-    QString tpl = sp+obj.value("template").toString();
+    QString tpl;
+    if (obj.contains("template_shortened") && else_present == false) {
+        tpl = sp+obj.value("template_shortened").toString();
+    }
+    else {
+        tpl = sp+obj.value("template").toString();
+    }
+
     for(int i = 0; i < element.attributes().size(); ++i) {
        if(obj.contains("list")) {
            QJsonArray list = obj["list"].toArray();


### PR DESCRIPTION
Закрывает issue #50 и #51.
Убрана точка с запятой после вызова функции и после присвоения.
Для Python используется 4-х пробельный отступ из json файла в тех случаях, когда он есть.
Для оператора ветвления в Python добавлена сокращенная форма без "else" которая используется если ветка "else" пуста.
Функция main вызывается после своего описания.
Заменён xrange на range. xrange это пережиток Python 2, в третьей версии его нет (судя по присутствию скобочек после print() сейчас код генерируется для Python 3).
Исправлен скролл колёсиком мышки. Есть вертикальный и горизонтальный(mouse wheel + shift) скролл.